### PR TITLE
fix: add webhooksPath property to enable function execution

### DIFF
--- a/function.js
+++ b/function.js
@@ -1,4 +1,4 @@
 const { createNodeMiddleware, createProbot } = require("probot");
 const app = require("./app");
 
-exports.probotApp = createNodeMiddleware(app, { probot: createProbot() });
+exports.probotApp = createNodeMiddleware(app, { probot: createProbot(), webhooksPath: "/" });


### PR DESCRIPTION
Sets the webhooksPath property in the example to enable the probot function to be executed.

Without this, the default path set by @octokit/webhooks when creating the middleware is /api/github/webhooks and the request always falls through to the next() handler.